### PR TITLE
Improve detection of capture group presence

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,7 +52,7 @@ const isRegExp = ( value: unknown ): value is RegExp => {
 
 const isRegExpCapturing = (() => { //TODO: Implement this perfectly instead, by parsing the regex
 
-  const sourceRe = /\\\(|\((?!\?(?::|=|!|<=|<!))/;
+  const sourceRe = /^(?:\\.|\[(?:\\.|[^\\\]])*\]|[^\\\[])*?\((?:[^?]|\?<[^=!])/;
 
   return ( re: RegExp ): boolean => {
 


### PR DESCRIPTION
As suggested at https://x.com/gibson042/status/1958775673797120398 and updated to include named capture groups.

Note that this is still not reliable for patterns with flag `v`, which supports nested character classes.